### PR TITLE
bench: fix BoundedEventBus publish benchmark methodology

### DIFF
--- a/LogWatcher.Benchmarks/BoundedEventBusBenchmarks.cs
+++ b/LogWatcher.Benchmarks/BoundedEventBusBenchmarks.cs
@@ -1,11 +1,17 @@
 using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
 
 using LogWatcher.Core.Backpressure;
 using LogWatcher.Core.Ingestion;
 
 namespace LogWatcher.Benchmarks;
 
+// InvocationCount=1000: each BDN iteration runs exactly 1000 publish calls.
+// For Publish_BusHasCapacity this is well below the 100_000-item capacity, so
+// the bus never fills mid-iteration. For Publish_BusFull the bus stays full
+// throughout all 1000 invocations (pre-filled by IterationSetup).
 [MemoryDiagnoser]
+[SimpleJob(invocationCount: 1000)]
 public class BoundedEventBusBenchmarks
 {
     // Large enough that the benchmark never fills it during a normal run.
@@ -26,24 +32,33 @@ public class BoundedEventBusBenchmarks
             DateTimeOffset.UtcNow,
             true);
 
-        _bus = new BoundedEventBus<FsEvent>(10_000);
+        // 100_000 capacity ensures the bus never fills during a single iteration
+        // (InvocationCount=1000 on Publish_BusHasCapacity is well below this).
+        _bus = new BoundedEventBus<FsEvent>(100_000);
         _fullBus = new BoundedEventBus<FsEvent>(1);
     }
 
-    // Ensure _fullBus is at capacity before each Publish_BusFull iteration.
-    [IterationSetup(Target = nameof(Publish_BusFull))]
-    public void FillBus() => _fullBus.Publish(_event);
-
-    // Drain _fullBus after each Publish_BusFull iteration.
-    [IterationCleanup(Target = nameof(Publish_BusFull))]
-    public void DrainBus() => _fullBus.TryDequeue(out _, 0);
-
-    // Ensure _bus has room before each Publish_BusHasCapacity iteration.
+    // Drain _bus fully before each Publish_BusHasCapacity iteration so accumulated
+    // items from previous iterations don't push the bus toward capacity.
     [IterationSetup(Target = nameof(Publish_BusHasCapacity))]
-    public void EnsureCapacity() => _bus.TryDequeue(out _, 0);
+    public void DrainBusForCapacity()
+    {
+        while (_bus.TryDequeue(out _, 0)) { }
+    }
+
+    // Drain then pre-fill _fullBus before each Publish_BusFull iteration so every
+    // publish call during measurement hits a full bus and drops immediately.
+    [IterationSetup(Target = nameof(Publish_BusFull))]
+    public void PreFillBus()
+    {
+        while (_fullBus.TryDequeue(out _, 0)) { }
+        _fullBus.Publish(_event);
+    }
 
     /// <summary>
     /// Happy path: bus always has room. Measures the cost of a successful enqueue.
+    /// InvocationCount=1000 (class-level SimpleJob) is well below the 100_000-item
+    /// capacity, so the bus never fills during a single BDN iteration.
     /// </summary>
     [Benchmark]
     public bool Publish_BusHasCapacity() => _bus.Publish(_event);


### PR DESCRIPTION
## Summary

Restructures the `Publish_BusHasCapacity` and `Publish_BusFull` benchmarks so BenchmarkDotNet can run multiple invocations per iteration, producing stable means with StdDev well below 10%.

## Problem

The original benchmarks had structural issues causing 2431% StdDev:

1. **Bus capacity (10,000) too close to BDN auto-selected invocation count**  bus could silently fill mid-iteration, changing what was being measured
2. **`EnsureCapacity` only dequeued 1 item**  didn't drain accumulated items from prior iterations; state bled across iterations
3. **No explicit `InvocationCount`**  BDN autopilot could choose any value, making bus saturation unpredictable

`TryDequeue_WithItem` at 70 ns with tight StdDev was the reference for a correctly-structured benchmark.

## Changes

| Change | Reason |
|--------|--------|
| Added `[SimpleJob(invocationCount: 1000)]` at class level | Fixes 1000 invocations/iteration; BDN runs many iterations to compute stable mean |
| Increased bus capacity 10,000  100,000 | 100 headroom above InvocationCount=1000; bus never fills mid-iteration |
| `EnsureCapacity`  `DrainBusForCapacity()` with full drain loop | Eliminates accumulated-item bleed across iterations |
| `FillBus`  `PreFillBus()` with drain-then-fill | Robustly resets bus to exactly-full state before each measured iteration |

## Benchmark Results

**Environment:** Windows 11, Intel Core i7-12700K, .NET 10.0.1 (10.0.125.57005), X64 RyuJIT AVX2

```
BenchmarkDotNet v0.13.12
[SimpleJob] InvocationCount=1000, UnrollFactor=1
```

| Method | Mean | Error | StdDev | StdErr | Allocated |
|---|---|---|---|---|---|
| `Publish_BusHasCapacity` | 49.77 ns | 0.530 ns | 0.442 ns | **<1%** | 0 B |
| `Publish_BusFull` | 18.47 ns | 0.119 ns | 0.111 ns | **<1%** | 0 B |
| `TryDequeue_WithItem` | 104.34 ns | 3.051 ns | 8.556 ns | **8.2%** | 0 B |

All three benchmarks are now below the 10% StdDev target. The drop path (`Publish_BusFull`) is correctly cheaper than the enqueue path (`Publish_BusHasCapacity`)  consistent with the implementation skipping the lock-and-queue work when the bus is full.

## Acceptance Criteria

- [x] Both publish benchmarks run under explicit `InvocationCount=1000`
- [x] StdDev below 10% of mean  all three at <1%, <1%, and 8.2% respectively
- [x] Bus never fills mid-iteration (`Publish_BusHasCapacity`: 1000 items vs 100,000 capacity)
- [x] `Publish_BusFull` bus guaranteed full on every invocation (drain-then-fill in `[IterationSetup]`)
- [x] 0 B allocated across all benchmarks
- [x] Build passes: zero errors, zero warnings
- [x] No changes to `BoundedEventBus` implementation or test files