### PR TITLE
ci: remove windows-latest from test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,10 +44,7 @@ jobs:
         run: dotnet build --no-restore --configuration Debug --verbosity normal
 
   test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ ubuntu-latest, windows-latest ]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.1
       - name: Setup .NET


### PR DESCRIPTION
## Summary

Removes `windows-latest` from the `test` job OS matrix and collapses the single-element matrix entirely.

## Changes

- Replaced `runs-on: ${{ matrix.os }}` with `runs-on: ubuntu-latest`
- Removed the `strategy.matrix` block (`os: [ubuntu-latest, windows-latest]`)
- No other changes  steps are identical to the current Ubuntu leg

## Rationale

LogWatcher targets Linux-based deployment. The Windows runner provided no additional coverage benefit beyond what the Ubuntu runner already covers, while adding CI time and cost.

## Acceptance Criteria

- [x] `test` job runs on `ubuntu-latest` only
- [x] No `strategy` or `matrix` keys remain in the job
- [x] CI pass/fail behavior otherwise unchanged
