### PR TITLE
perf: replace hand-rolled for loops with span.IndexOf in Utf8LineScanner

### DIFF
--- a/LogWatcher.Core/Processing/Scanning/Utf8LineScanner.cs
+++ b/LogWatcher.Core/Processing/Scanning/Utf8LineScanner.cs
@@ -29,15 +29,7 @@ namespace LogWatcher.Core.Processing.Scanning
             if (carry.Length > 0)
             {
                 // find first '\n' in chunk
-                int nlIndex = -1;
-                for (int i = 0; i < chunk.Length; i++)
-                {
-                    if (chunk[i] == (byte)'\n')
-                    {
-                        nlIndex = i;
-                        break;
-                    }
-                }
+                int nlIndex = chunk.IndexOf((byte)'\n');
 
                 if (nlIndex == -1)
                 {
@@ -70,15 +62,8 @@ namespace LogWatcher.Core.Processing.Scanning
             int start = 0;
             while (start < chunk.Length)
             {
-                int j = -1;
-                for (int i = start; i < chunk.Length; i++)
-                {
-                    if (chunk[i] == (byte)'\n')
-                    {
-                        j = i;
-                        break;
-                    }
-                }
+                int sliceIndex = chunk.Slice(start).IndexOf((byte)'\n');
+                int j = sliceIndex == -1 ? -1 : start + sliceIndex;
 
                 if (j == -1)
                     break; // no more newlines


### PR DESCRIPTION
## Audit Finding

Addresses the finding in `audit/LogWatcher.Core.md`: `Utf8LineScanner.cs` contained two hand-rolled `for` loops searching for `(byte)'\n'`, violating the BCL best-practice rule:

> **Span byte search | hand-rolled `for` loop | `span.IndexOf(value)`**

## What Changed

**File:** `LogWatcher.Core/Processing/Scanning/Utf8LineScanner.cs`

**Carry path** (loop 1)  replaced 6-line `for` loop:
```csharp
int nlIndex = chunk.IndexOf((byte)'\n');
```

**Main scan path** (loop 2)  replaced 6-line `for` loop iterating from `start`:
```csharp
int sliceIndex = chunk.Slice(start).IndexOf((byte)'\n');
int j = sliceIndex == -1 ? -1 : start + sliceIndex;
```

The slice + rebase pattern preserves exact semantics: `IndexOf` returns an index relative to the slice, so adding `start` converts it back to an index into the original `chunk`.

## Why

- Delegates newline search to the BCL's optimised `IndexOf` (SIMD-accelerated on supported platforms)
- Eliminates 15 lines of hand-rolled boilerplate
- Pure algorithmic substitution  identical observable behaviour

## Verification

```
dotnet format --no-restore         Format complete, no changes required
dotnet test  --no-restore -c Release  total: 220, failed: 0, succeeded: 220
```