### PR TITLE
refactor: convert PartialLineBuffer properties to public fields

### DIFF
--- a/LogWatcher.Core/FileManagement/PartialLineBuffer.cs
+++ b/LogWatcher.Core/FileManagement/PartialLineBuffer.cs
@@ -9,12 +9,14 @@ public struct PartialLineBuffer
     /// <summary>
     /// Underlying buffer that stores appended bytes. May be <c>null</c> when empty.
     /// </summary>
-    public byte[]? Buffer { get; private set; }
+#pragma warning disable CA1051
+    public byte[]? Buffer;
 
     /// <summary>
     /// Number of valid bytes in <see cref="Buffer"/> (0..Buffer.Length).
     /// </summary>
-    public int Length { get; private set; }
+    public int Length;
+#pragma warning restore CA1051
 
     private const int InitialSize = 256;
 


### PR DESCRIPTION
## Summary

Converts `PartialLineBuffer.Buffer` and `PartialLineBuffer.Length` from auto-properties with `private set` to plain public fields.

The struct's own XML doc already stated _"simple data shape (public fields) for performance and interoperability"_, but the implementation contradicted this by using `{ get; private set; }` accessors.

**Rule violated (dotnet.instructions.md  Pipeline and Systems-Level Code):**
> DO NOT reflexively convert fields to properties on mutable structs and hot-path state objects  adds indirection, emits false encapsulation signal on types explicitly mutable by design.

## Changes

- `LogWatcher.Core/FileManagement/PartialLineBuffer.cs`  two property declarations replaced with plain public fields; `#pragma warning disable CA1051` added since the public-field design is intentional and explicitly documented.

## No caller changes needed

All external callers only read `Buffer` and `Length`  no caller ever assigned to them (that would have failed with `private set`). Internal methods (`Append`, `Clear`, `Release`) assign to these members and continue to compile identically with fields.

## Verification

```
dotnet build --no-restore --configuration Debug    Build succeeded, 0 warnings, 0 errors
dotnet format --no-restore                          No changes
dotnet test --no-restore --configuration Release    Passed: 220, Failed: 0
```