### PR TITLE
refactor(tests): clarify invariant classification and strip ambiguous TODOs

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -184,7 +184,7 @@ public void Bus_NeverExceedsCapacity() { ... }
 - **Test structure**: Mirror source structure — `Unit/`, `Integration/`, `Stress/`.
 - **Test naming**: `MethodOrScenario_Condition_ExpectedBehavior` (PascalCase, underscores between parts).
 - **Determinism**: No timing-based assertions. No network. No dependency on installed software.
-- **Invariant tagging**: Apply `[Invariant("ID")]` from `docs/invariants.md` to all tests that protect a documented invariant.
+- **Invariant tagging**: Apply `[Invariant("ID")]` from `docs/invariants.md` to all tests that protect a documented invariant. An invariant is an architectural guarantee that crosses a component boundary or describes a system-wide safety property — not all correct behavior qualifies. Tests without `[Invariant]` are complete; the absence of a tag means the behavior is self-contained within one component and needs no cross-cutting documentation.
 - **Stress tests**: Live in `Stress/` and may use real threads; they must still terminate reliably without timing-based flakiness.
 - **Coverage check**: `InvariantCoverageTests.cs` enforces that every documented invariant in `docs/invariants.md` is covered by at least one `[Invariant("ID")]` test — do not break this.
 

--- a/LogWatcher.Tests/Integration/ReporterTests.cs
+++ b/LogWatcher.Tests/Integration/ReporterTests.cs
@@ -8,7 +8,6 @@ namespace LogWatcher.Tests.Integration;
 
 public class ReporterTests
 {
-    // TODO: map to invariant
     [Fact]
     public void BuildSnapshotAndFrame_WithPopulatedWorkerBuffers_MergesAllMetrics()
     {
@@ -58,7 +57,6 @@ public class ReporterTests
         Assert.Equal(0, snap.BusDropped);
     }
 
-    // TODO: map to invariant
     [Fact]
     public void BuildSnapshotAndFrame_WithMessagesAndLatencies_ComputesTopKAndPercentiles()
     {

--- a/LogWatcher.Tests/Unit/App/CommandConfigurationTests.cs
+++ b/LogWatcher.Tests/Unit/App/CommandConfigurationTests.cs
@@ -23,7 +23,6 @@ public class CommandConfigurationTests : IDisposable
         }
     }
 
-    // TODO: map to invariant
     [Fact]
     public void Parse_WithDirectoryArgument_Succeeds()
     {
@@ -35,7 +34,6 @@ public class CommandConfigurationTests : IDisposable
         Assert.Empty(parseResult.Errors);
     }
 
-    // TODO: map to invariant
     [Fact]
     public void Parse_WithAllOptions_Succeeds()
     {
@@ -47,7 +45,6 @@ public class CommandConfigurationTests : IDisposable
         Assert.Empty(parseResult.Errors);
     }
 
-    // TODO: map to invariant
     [Fact]
     public void Parse_WithMissingPath_ReturnsErrors()
     {
@@ -59,7 +56,6 @@ public class CommandConfigurationTests : IDisposable
         Assert.NotEmpty(parseResult.Errors);
     }
 
-    // TODO: map to invariant
     [Fact]
     public void Parse_WithInvalidNumber_ReturnsErrors()
     {
@@ -71,7 +67,6 @@ public class CommandConfigurationTests : IDisposable
         Assert.NotEmpty(parseResult.Errors);
     }
 
-    // TODO: map to invariant
     [Fact]
     public void Parse_WhenHelpRequested_ReturnsNoErrors()
     {

--- a/LogWatcher.Tests/Unit/Core/Backpressure/BoundedEventBusTests.cs
+++ b/LogWatcher.Tests/Unit/Core/Backpressure/BoundedEventBusTests.cs
@@ -24,7 +24,6 @@ public class BoundedEventBusTests
         Assert.Equal(2, bus.Depth);
     }
 
-    // TODO: map to invariant
     [Fact]
     public void TryDequeue_WithMultiplePublishedItems_ReturnsInFifoOrder()
     {

--- a/LogWatcher.Tests/Unit/Core/Ingestion/FilesystemWatcherAdapterTests.cs
+++ b/LogWatcher.Tests/Unit/Core/Ingestion/FilesystemWatcherAdapterTests.cs
@@ -26,7 +26,6 @@ public class FilesystemWatcherAdapterTests : IDisposable
         }
     }
 
-    // TODO: map to invariant
     [Fact]
     public void Start_WhenLogFileCreated_PublishesEventToBus()
     {

--- a/LogWatcher.Tests/Unit/Core/Processing/FileProcessorTests.cs
+++ b/LogWatcher.Tests/Unit/Core/Processing/FileProcessorTests.cs
@@ -53,7 +53,6 @@ public class FileProcessorTests : IDisposable
         }
     }
 
-    // TODO: map to invariant
     [Fact]
     public void ProcessOnce_WithAppendedContent_ReadsOnlyNewBytes()
     {

--- a/LogWatcher.Tests/Unit/Core/Processing/Parsing/LogParserTests.cs
+++ b/LogWatcher.Tests/Unit/Core/Processing/Parsing/LogParserTests.cs
@@ -45,7 +45,6 @@ public class LogParserTests
         Assert.False(LogParser.TryParse(line, out _));
     }
 
-    // TODO: map to invariant
     [Fact]
     public void TryParse_WithUnknownLevel_MapsToOther()
     {

--- a/LogWatcher.Tests/Unit/Core/Processing/Tailing/FileTailerTests.cs
+++ b/LogWatcher.Tests/Unit/Core/Processing/Tailing/FileTailerTests.cs
@@ -30,8 +30,8 @@ public class FileTailerTests : IDisposable
         return Path.Combine(_dir, name);
     }
 
-    // TODO: map to invariant
     [Fact]
+    [Invariant("TAIL-006")]
     public void ReadAppended_WithAppendedContent_ReadsOnlyNewBytes()
     {
         var p = MakePath("log1.txt");

--- a/LogWatcher.Tests/Unit/Core/Reporting/GlobalSnapshotTests.cs
+++ b/LogWatcher.Tests/Unit/Core/Reporting/GlobalSnapshotTests.cs
@@ -5,7 +5,6 @@ namespace LogWatcher.Tests.Unit.Core.Reporting;
 
 public class GlobalSnapshotTests
 {
-    // TODO: map to invariant
     [Fact]
     public void MergeFrom_WithWorkerBuffer_SumsAllMetrics()
     {
@@ -28,7 +27,6 @@ public class GlobalSnapshotTests
         Assert.Equal(3, snap.Histogram.Count);
     }
 
-    // TODO: map to invariant
     [Fact]
     public void FinalizeSnapshot_WithMessagesAndLatencies_ComputesTopKAndPercentiles()
     {

--- a/LogWatcher.Tests/Unit/Core/Statistics/LatencyHistogramTests.cs
+++ b/LogWatcher.Tests/Unit/Core/Statistics/LatencyHistogramTests.cs
@@ -4,8 +4,8 @@ namespace LogWatcher.Tests.Unit.Core.Statistics;
 
 public class LatencyHistogramTests
 {
-    // TODO: map to invariant
     [Fact]
+    [Invariant("STAT-006")]
     public void Percentile_WhenHistogramEmpty_ReturnsNull()
     {
         var h = new LatencyHistogram();

--- a/LogWatcher.Tests/Unit/Core/Statistics/TopKTests.cs
+++ b/LogWatcher.Tests/Unit/Core/Statistics/TopKTests.cs
@@ -4,7 +4,6 @@ namespace LogWatcher.Tests.Unit.Core.Statistics;
 
 public class TopKTests
 {
-    // TODO: map to invariant
     [Fact]
     public void ComputeTopK_WhenDictionaryEmpty_ReturnsEmpty()
     {
@@ -12,7 +11,6 @@ public class TopKTests
         Assert.Empty(res);
     }
 
-    // TODO: map to invariant
     [Fact]
     public void ComputeTopK_WhenKExceedsCount_ReturnsAllItemsSorted()
     {
@@ -30,7 +28,6 @@ public class TopKTests
         Assert.Equal(("c", 1), res[2]);
     }
 
-    // TODO: map to invariant
     [Fact]
     public void ComputeTopK_WithEqualCounts_BreaksTiesByOrdinalAscending()
     {
@@ -48,7 +45,6 @@ public class TopKTests
         Assert.Equal("b", res[2].Key);
     }
 
-    // TODO: map to invariant
     [Fact]
     public void ComputeTopK_WithMixedCounts_ReturnsTopKByCountDescending()
     {

--- a/LogWatcher.Tests/Unit/Core/Statistics/WorkerStatsBufferTests.cs
+++ b/LogWatcher.Tests/Unit/Core/Statistics/WorkerStatsBufferTests.cs
@@ -27,7 +27,6 @@ public class WorkerStatsBufferTests
         Assert.Null(b.Histogram.Percentile(0.5));
     }
 
-    // TODO: map to invariant
     [Fact]
     public void IncrementMessage_CalledMultipleTimes_AccumulatesCountsCorrectly()
     {

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -20,6 +20,42 @@ correctness during code review.
 
 ---
 
+## Invariant Decision Table
+
+An invariant is an **architectural guarantee** — a property that crosses a component boundary or
+describes a system-wide safety rule that multiple components depend on. Correct behavior that is
+self-contained within one component is not an invariant; leave it untagged.
+
+**Step 1 — Disqualify.** If any row below matches, it is not an invariant. Leave the test untagged.
+
+"Caller" means the *next component in the dependency chain*, not the end user.
+
+| This behavior is… | Example |
+|---|---|
+| Self-contained within one component; no downstream component depends on it | TopK sort order, merge summation, message accumulation |
+| An internal implementation detail invisible to callers | Chunk size, buffer capacity, timeout values |
+| A quality-of-life or ergonomic concern | API shape, logging, configurability |
+| A performance target scoped to reporting or startup | Allocation during report formatting |
+| Visible in output but any correct alternative would be equally acceptable | Tie-breaking order, dequeue ordering, default sort stability |
+
+**Step 2 — Classify.** If none of the above matched, pick the type using the first row that applies.
+
+| If a violation would… | Type |
+|---|---|
+| Cause data loss, corruption, or a crash | `strict` |
+| Break an assumption both sides of a component boundary rely on | `contract` |
+| Degrade observable behavior but leave the system operational | `behavioral` |
+| Only occur under resource exhaustion or OS failure | `operational` |
+
+**Edge case note.** An edge case qualifies as an invariant only if the calling component makes a distinct
+decision based on the specific value returned (e.g., null vs. 0 changes a branch). If all values are
+treated uniformly by callers, the edge case is self-contained and does not qualify.
+
+**Allocation note.** Per-line or per-chunk heap allocation in the hot path is a `strict` invariant because it directly
+causes observable GC pressure and latency spikes. Allocation during reporting or startup is not an invariant.
+
+---
+
 ## Attribute Usage
 
 Tag tests with `[Invariant("ID")]` to declare which invariant a test protects.

--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -122,6 +122,7 @@ public void Publish_WhenFull_DropsNewestAndPreservesExisting() { ... }
 | TAIL-003 | `strict`     | TAIL       | Allocated read buffers are always released regardless of read outcome.                                                     |
 | TAIL-004 | `behavioral` | TAIL       | File not found, access denied, and IO errors are mapped to status codes and never propagated as exceptions to the caller.  |
 | TAIL-005 | `contract`   | TAIL, PROC | The span passed to `onChunk` is only valid for the duration of the callback and must not be retained by the caller.        |
+| TAIL-006 | `contract`   | TAIL, PROC | After a successful read, the caller's offset is advanced by exactly the number of bytes delivered. A subsequent call with that offset reads only bytes appended since the previous call and never re-delivers already-consumed bytes. |
 
 ---
 
@@ -166,11 +167,12 @@ public void Publish_WhenFull_DropsNewestAndPreservesExisting() { ... }
 
 | ID       | Type       | Domains | Description                                                                                                                                             |
 |----------|------------|---------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
-| STAT-001 | `strict`   | STAT    | Level counts are indexed by the integer value of `LogLevel`. An unrecognized index is silently ignored and never throws.                                |
-| STAT-002 | `strict`   | STAT    | Histogram bin counts never decrease within a single buffer lifetime.                                                                                    |
-| STAT-003 | `strict`   | STAT    | Histogram total count always equals the sum of all bin counts.                                                                                          |
-| STAT-004 | `contract` | STAT    | `Reset()` returns the buffer to an observable zero state. Callers must not assume anything about the internal capacity or allocation state after reset. |
-| STAT-005 | `strict`   | STAT    | Latency values outside the supported range are mapped to an overflow bucket. No exception is thrown and no value is silently discarded.                 |
+| STAT-001 | `strict`   | STAT      | Level counts are indexed by the integer value of `LogLevel`. An unrecognized index is silently ignored and never throws.                                |
+| STAT-002 | `strict`   | STAT      | Histogram bin counts never decrease within a single buffer lifetime.                                                                                    |
+| STAT-003 | `strict`   | STAT      | Histogram total count always equals the sum of all bin counts.                                                                                          |
+| STAT-004 | `contract` | STAT      | `Reset()` returns the buffer to an observable zero state. Callers must not assume anything about the internal capacity or allocation state after reset. |
+| STAT-005 | `strict`   | STAT      | Latency values outside the supported range are mapped to an overflow bucket. No exception is thrown and no value is silently discarded.                 |
+| STAT-006 | `contract` | STAT, RPT | `Percentile()` returns `null` when the histogram contains no data. Callers may rely on `null` to distinguish "no measurements recorded" from a zero-valued measurement. |
 
 ---
 


### PR DESCRIPTION
## Summary

Establishes a precise definition of what qualifies as an invariant in this codebase, resolves all `// TODO: map to invariant` comments in the test suite, and adds two new invariant IDs for tests that genuinely crossed component boundaries.

## Problem

The test suite had 20 tests tagged with `// TODO: map to invariant`, implying every test should eventually become a documented invariant. This was incorrect  many tests cover single-component behavior that is self-contained and needs no cross-cutting documentation. The absence of `[Invariant]` on any test was ambiguous: gap or intentional?

## Definition Established

**An invariant is an architectural guarantee**  a property that crosses a component boundary or describes a system-wide safety rule that multiple components depend on. Correct behavior self-contained within one component does not qualify regardless of how observable or important it is.

## Changes

### `docs/invariants.md`
Added an **Invariant Decision Table** anchored to the definition above, with a two-step disqualify/classify flow. Includes an edge case note (caller must branch on the specific value), an allocation note, and the self-contained-within-one-component row as the primary disqualifier.

Added two new invariant IDs:
- **TAIL-006** (contract, TAIL+PROC): after a successful read, the caller's offset is advanced by exactly the bytes delivered; subsequent reads never re-deliver already-consumed bytes
- **STAT-006** (contract, STAT+RPT): `Percentile()` returns `null` when the histogram contains no data; the reporter depends on `null` to distinguish no measurements from a zero-valued measurement

### `.github/copilot-instructions.md`
Expanded the invariant tagging convention to explicitly state that untagged tests are intentionally complete  absence of a tag means the behavior is self-contained and needs no cross-cutting documentation.

### Test files (10 files)
Removed all 20 `// TODO: map to invariant` comments:
- **17 removed**  tests covering single-component behavior (TopK sorting, message accumulation, merge summation, CLI parsing, FIFO ordering, level mapping, reporter snapshot computation) do not qualify as invariants and are correctly left untagged
- **2 resolved**  `FileTailerTests` and `LatencyHistogramTests` tagged with `[Invariant("TAIL-006")]` and `[Invariant("STAT-006")]` respectively
- **1 removed from FileProcessorTests**  offset correctness at the processor level follows from the lower-level TAIL and FM contracts; no additional PROC invariant needed

## Verification

All 130 tests pass including `InvariantCoverageTests` (forward: every ID in `invariants.md` has a tagged test; reverse: every tag references a defined ID). Zero `// TODO: map to invariant` comments remain in the codebase.
