### PR TITLE
feat: add --no-fail flag to compare.py and wire in CI perf-test job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,4 +137,5 @@ jobs:
           python benchmarks/compare.py \
             --baseline-dir benchmarks/baseline \
             --current-dir BenchmarkDotNet.Artifacts/results \
-            --threshold ${{ inputs.threshold || '0.15' }}
+            --threshold ${{ inputs.threshold || '0.15' }} \
+            --no-fail

--- a/benchmarks/compare.py
+++ b/benchmarks/compare.py
@@ -87,6 +87,7 @@ def main() -> int:
     parser.add_argument("--baseline-dir", required=True, help="Directory containing baseline *-report-full.json files")
     parser.add_argument("--current-dir", required=True, help="Directory containing current *-report-full.json files")
     parser.add_argument("--threshold", type=float, default=0.15, help="Regression threshold (default: 0.15 = 15%%)")
+    parser.add_argument("--no-fail", action="store_true", help="Print results but always exit 0 (never gate the job)")
     args = parser.parse_args()
 
     current_files = [
@@ -110,10 +111,13 @@ def main() -> int:
     print()
     if all_passed:
         print("✅ All benchmarks within threshold.")
-        return 0
     else:
-        print(f"❌ One or more benchmarks regressed by more than {args.threshold:.0%}.")
-        return 1
+        suffix = " (no-fail mode — job will not be marked failed)" if args.no_fail else ""
+        print(f"❌ One or more benchmarks regressed by more than {args.threshold:.0%}.{suffix}")
+
+    if args.no_fail:
+        return 0
+    return 0 if all_passed else 1
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add a --no-fail boolean argument to benchmarks/compare.py. When set, the full comparison runs and all output (including *** REGRESSION *** markers and the final summary line) is printed, but the script always exits 0. The failure summary line gains a parenthetical note indicating no-fail mode is active so the result remains visible in CI logs.

Wire --no-fail into the perf-test job's 'Check for regressions' step in .github/workflows/ci.yml. Benchmark artifacts are already uploaded before the check step, so artifacts are always generated. The job now completes regardless of regression outcome.