### PR TITLE
feat: add devcontainer for Ubuntu 24.04 with .NET 10, Python 3.12, and Docker-in-Docker

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,28 @@
+﻿{
+  "name": "LogWatcher-DevContainer",
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu24.04",
+  "features": {
+    "ghcr.io/devcontainers/features/python:1" : {
+      "version": "3.12",
+      "installTools": false
+    },
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
+    "ghcr.io/devcontainers/features/dotnet:2": {
+      "version": "10.0"
+    }
+  },
+  "postCreateCommand": "dotnet restore",
+  "customizations": {
+    "jetbrains": {
+      "backend": "Rider",
+      "plugins": [
+        "com.github.copilot",
+        "com.intellij.resharper.HeapAllocationsViewer"
+      ]
+    }
+  },
+  "mounts": [
+    "source=${localWorkspaceFolder}/temp,target=${containerWorkspaceFolder}/temp,type=bind"
+  ],
+  "remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,4 @@
-﻿{
+{
   "name": "LogWatcher-DevContainer",
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu24.04",
   "features": {

--- a/.idea/.idea.LogWatcher/.idea/indexLayout.xml
+++ b/.idea/.idea.LogWatcher/.idea/indexLayout.xml
@@ -2,7 +2,9 @@
 <project version="4">
   <component name="UserContentModel">
     <attachedFolders />
-    <explicitIncludes />
+    <explicitIncludes>
+      <Path>.devcontainer/devcontainer.json</Path>
+    </explicitIncludes>
     <explicitExcludes />
   </component>
 </project>

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
   "sdk": {
-    "version": "10.0.101"
+    "version": "10.0.101",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
## Summary
- Adds `.devcontainer/devcontainer.json` configuring an Ubuntu 24.04 base image with .NET 10, Python 3.12, and Docker-in-Docker features
- Configures JetBrains Rider as the backend with Copilot and HeapAllocationsViewer plugins
- Runs `dotnet restore` on container creation and mounts the local `temp/` folder into the container
- Updates `global.json` to set `rollForward: latestFeature` so the SDK resolves to the latest feature band of 10.0

## Test plan
- [ ] Open repo in a devcontainer-compatible IDE (e.g., VS Code or Rider) and verify the container builds successfully
- [ ] Confirm `dotnet restore` completes without errors post-create
- [ ] Verify `temp/` bind mount is accessible inside the container
- [ ] Confirm `dotnet --version` reports a 10.0.x SDK with latestFeature rollForward