### PR TITLE
Add GitHub issue templates with domain impact and EARS requirements

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,159 @@
+---
+name: Bug Report
+about: Report incorrect or unexpected behavior
+labels: bug
+---
+
+## Summary
+
+<!--
+One sentence naming the broken behavior. This is a headline, not an explanation — details
+go in Behavior below. Name the domain and the violated guarantee if you already know them.
+Example: "File Tailing resets the read offset on rename events, causing lines to be
+processed twice."
+-->
+
+## Behavior
+
+<!--
+Expected: State the behavior as it should work, ideally in terms of the domain's declared
+Responsibility or a specific invariant from invariants.md. Anchor to the spec, not intuition.
+
+Actual: Describe exactly what happens instead. Be specific — include observable symptoms,
+not internal hypotheses. If you have a stack trace, error message, or log output, include it.
+-->
+
+**Expected:**
+
+**Actual:**
+
+## Steps to Reproduce
+
+<!--
+Minimal steps to observe the actual behavior. Include:
+  - Relevant command-line arguments or configuration values
+  - File structure or content that triggers the bug
+  - Whether the bug is deterministic or timing-dependent
+  - How frequently it reproduces (always, occasionally, only under load)
+-->
+
+1.
+2.
+3.
+
+## Domain Diagnosis
+
+<!--
+Identify the domain whose Responsibility or In Scope is being violated. This is the domain
+that *should* own correct behavior here — not necessarily the domain where the symptom first
+appears, which may be a downstream consumer observing the consequence of an upstream failure.
+
+If you traced the defect to a specific code location, name the namespace too, but lead with
+the domain name. If multiple domains share blame, list the one whose guarantee is ultimately
+broken as the primary row and note the others below it.
+-->
+
+Use names from [`docs/domain_boundaries.md`](../docs/domain_boundaries.md).
+
+| Domain | Responsibility Violated |
+|--------|------------------------|
+|        |                        |
+
+## Invariant Analysis
+
+<!--
+Which invariant from invariants.md does this bug violate? Use the exact invariant name or
+description from that document. If no named invariant covers it, that may mean the guarantee
+is implied but undocumented — note that here, as it may need to be added to invariants.md.
+
+Types:
+  strict       — Causes data loss, corruption, or a crash.
+  behavioral   — Degrades observable behavior but the system keeps running.
+  contract     — Breaks an assumption both sides of a domain boundary rely on.
+  operational  — Only occurs under resource exhaustion or OS failure.
+
+If the type is strict, note whether the bug has been observed in production.
+-->
+
+| Invariant | Type |
+|-----------|------|
+|           |      |
+
+## Fix Scope
+
+<!--
+List every domain that must change to fix this bug. This often — but not always — matches
+the domain in Domain Diagnosis. It may differ when:
+  - The root cause is in a dependency that feeds the diagnosed domain
+  - A contract between two domains is wrong and both sides must be corrected
+  - A data structure's schema must be fixed at its owning domain, not at the consumer
+
+Keep scope as narrow as possible. A bug fix must not expand a domain's In Scope unless
+that expansion is the fix itself. If scope creep is tempting, open a separate feature issue.
+-->
+
+| Domain | Change Type | Description |
+|--------|-------------|-------------|
+|        |             |             |
+
+**Change types:** `In Scope` · `Contract` · `Data Ownership` · `Dependency Direction`
+
+> Any domain not listed here must not be modified to fix this issue. Update this table before touching any unlisted domain's namespace.
+
+## Requirements
+
+<!--
+Express what correct behavior looks like using EARS syntax. These requirements describe
+the fixed system — not the current broken behavior and not how to implement the fix, but
+what "correct" means when the fix is complete.
+
+  Event-driven: When <trigger>, the <domain> shall <response>.
+  Unwanted:     If <unwanted condition>, then the <domain> shall <response>.
+  State-driven: While <state>, the <domain> shall <response>.
+
+If the fix is restoring a broken invariant, the requirement should restate that invariant
+directly. Each requirement here must correspond to at least one acceptance criterion below.
+-->
+
+-
+
+## Edge Cases
+
+<!--
+Related conditions that the same fix should address. Think through:
+  - Other inputs or states that trigger the same root cause
+  - Conditions where the fix itself could fail or produce incorrect behavior
+  - Variants of the bug that may exist in sibling domains
+
+If an edge case is out of scope for this fix, note it here and file a separate issue.
+Do not leave related edge cases undocumented just because they are deferred.
+-->
+
+-
+
+## Acceptance Criteria
+
+<!--
+Each criterion must be independently verifiable. At minimum, one criterion should directly
+confirm the invariant identified in Invariant Analysis is restored. Do not restate the
+implementation ("the offset is no longer reset") — state the observable outcome
+("lines are processed exactly once per file modification event").
+-->
+
+- [ ]
+- [ ]
+
+## Test Plan
+
+<!--
+List the tests that will verify the fix. For each test note:
+  - Which invariant it verifies
+  - Which domain(s) it exercises
+  - Whether it is a regression test for this specific bug — mark these clearly so they
+    are never removed
+
+Regression tests should reproduce the exact conditions of the bug before asserting the fix.
+If the bug was timing-dependent, note how the test makes the race deterministic.
+-->
+
+-

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,143 @@
+---
+name: Feature Request
+about: Propose a new capability or behavior change
+labels: enhancement
+---
+
+## Summary
+
+<!--
+One sentence, active voice. State what the system gains — not why it is needed (that is
+Motivation) and not how it works (that is Requirements).
+Example: "The Reporting domain shall emit structured JSON in addition to the current console format."
+-->
+
+## Motivation
+
+<!--
+Describe the gap or problem this feature addresses. What cannot the system do today?
+What breaks down, becomes fragile, or is missing without it? Do not describe the solution
+here — Requirements handles that. Focus on the problem so that an alternative design could
+be evaluated against the same motivation.
+-->
+
+## Requirements
+
+<!--
+Each requirement is one EARS statement. Every "shall" is a testable obligation.
+Pick the pattern that matches the trigger:
+
+  Ubiquitous:   The <domain> shall <response>.
+  Event-driven: When <trigger>, the <domain> shall <response>.
+  State-driven: While <state>, the <domain> shall <response>.
+  Conditional:  If <condition>, the <domain> shall <response>.
+  Unwanted:     If <unwanted condition>, then the <domain> shall <response>.
+
+Use domain names from domain_boundaries.md as the subject (e.g., "the Log Parsing domain",
+"the Event Distribution domain"). Avoid implementation language — no class names, method
+signatures, or internal field references. If a requirement needs the word "and" to be
+complete, split it into two requirements.
+-->
+
+-
+
+## Edge Cases
+
+<!--
+Requirements for conditions outside the happy path. Every edge case is still a "shall"
+statement — not a note or a question. If it matters, it is a requirement.
+
+Think through:
+  - What if the input is malformed, empty, or at a boundary value?
+  - What if a resource (file, queue, buffer) is exhausted or unavailable?
+  - What if events arrive out of order or in rapid succession?
+  - What if this feature is activated mid-operation rather than at startup?
+
+Use EARS unwanted or conditional patterns. Example:
+  "If the output file cannot be opened, then the Reporting domain shall continue emitting
+  to the console and record a dropped-output counter."
+-->
+
+-
+
+## Domain Impact
+
+<!--
+For each domain whose namespace will be touched, add a row. If you are unsure whether a
+domain is affected, read its Responsibility and In Scope list in domain_boundaries.md —
+if the change requires adding, removing, or altering anything in that namespace, it belongs here.
+
+Change types:
+  In Scope            — A capability is being added to or removed from this domain's
+                        owned responsibilities.
+  Contract            — A behavioral interface (method, delegate, event) or a data
+                        structure crossing this domain's boundary is changing shape.
+  Data Ownership      — A data structure's schema is changing, or ownership of a
+                        structure is moving between domains.
+  Dependency Direction — A new dependency edge is being added, or an existing edge
+                        is being reversed or removed.
+  New Domain          — A new domain is being introduced to own this capability. Its
+                        full definition (per domain_definition.md) must be drafted
+                        before implementation begins.
+-->
+
+List every domain this issue touches. Use names from [`docs/domain_boundaries.md`](../docs/domain_boundaries.md).
+
+| Domain | Change Type | Description |
+|--------|-------------|-------------|
+|        |             |             |
+
+> Any domain not listed here must not be modified to implement this issue. Update this table before touching any unlisted domain's namespace.
+
+## Invariant Impact
+
+<!--
+An invariant is a guarantee that crosses a component boundary or holds system-wide.
+For each invariant this feature introduces, changes, or could accidentally weaken, add a row.
+Reference invariants.md for the full list of existing invariants and their types.
+
+Effects:
+  introduced              — This feature establishes a new guarantee that did not exist before.
+  strengthened            — An existing guarantee's scope is expanded or made more strict.
+  weakened                — An existing guarantee's scope is narrowed or a condition is relaxed.
+                            Weakening a strict invariant requires explicit justification.
+  unchanged but relevant  — The invariant holds, but this feature touches the code path that
+                            enforces it; reviewers must verify it is not accidentally broken.
+
+If truly no invariant is introduced or affected, state "None." explicitly — omitting this
+section is not the same as None.
+-->
+
+| Invariant | Type | Effect |
+|-----------|------|--------|
+|           |      |        |
+
+**Types:** `strict` · `behavioral` · `contract` · `operational`
+**Effects:** `introduced` · `strengthened` · `weakened` · `unchanged but relevant`
+
+## Acceptance Criteria
+
+<!--
+Each criterion is a single, independently verifiable statement. Avoid vague criteria
+("handles edge cases", "works correctly") — if it cannot be checked off unambiguously,
+rewrite it. Every criterion must map to at least one requirement above. If a criterion
+has no backing requirement, either add the requirement or remove the criterion.
+-->
+
+- [ ]
+- [ ]
+
+## Test Plan
+
+<!--
+List the tests that will verify this feature. Organize by domain: group tests under
+the domain they exercise. For each test note:
+  - Which acceptance criterion it covers
+  - Which invariant it verifies, if any
+  - Whether it is a unit test (single domain in isolation) or integration test (cross-domain)
+
+Do not list tests for behavior already covered by existing tests unless this feature
+changes that behavior.
+-->
+
+-


### PR DESCRIPTION
Introduces feature_request.md and bug_report.md under .github/ISSUE_TEMPLATE/, each structured to flow top-to-bottom in the order a contributor would naturally have information. Both templates enforce explicit domain impact tables (keyed to domain_boundaries.md), separate invariant impact sections (keyed to invariants.md), EARS-syntax requirements, edge cases, acceptance criteria, and a test plan. config.yml disables blank issues so the templates are always used.