### PR TITLE
Fix #54: Remove Ingestion/Log Parsing boundary leaks from Statistics Collection

### DIFF
--- a/LogWatcher.Core/Processing/FileProcessor.cs
+++ b/LogWatcher.Core/Processing/FileProcessor.cs
@@ -8,6 +8,8 @@ using LogWatcher.Core.Statistics;
 
 using Microsoft.Extensions.Logging;
 
+using ParsingLogLevel = LogWatcher.Core.Processing.Parsing.LogLevel;
+
 namespace LogWatcher.Core.Processing
 {
     /// <summary>
@@ -127,7 +129,7 @@ namespace LogWatcher.Core.Processing
                 return;
             }
 
-            stats.IncrementLevel(parsed.Level);
+            stats.IncrementLevel(ToStatLevel(parsed.Level));
 
             // TODO: Encoding.UTF8.GetString allocates a new string for every line with a non-empty message key.
             // In a high-throughput scenario (many lines per second across many files) this creates sustained
@@ -140,6 +142,16 @@ namespace LogWatcher.Core.Processing
             if (parsed.LatencyMs is { } v)
                 stats.Histogram.Add(v);
         }
+
+        private static StatLevel ToStatLevel(ParsingLogLevel level) => level switch
+        {
+            ParsingLogLevel.Info  => StatLevel.Info,
+            ParsingLogLevel.Warn  => StatLevel.Warn,
+            ParsingLogLevel.Error => StatLevel.Error,
+            ParsingLogLevel.Debug => StatLevel.Debug,
+            ParsingLogLevel.Other => StatLevel.Other,
+            _ => throw new ArgumentOutOfRangeException(nameof(level), level, null),
+        };
 
         [LoggerMessage(Level = Microsoft.Extensions.Logging.LogLevel.Debug, Message = "Processed path={Path} status={Status} bytesRead={BytesRead} lines={Lines} malformed={Malformed}")]
         private static partial void LogProcessed(ILogger logger, string path, TailReadStatus status, int bytesRead, long lines, long malformed);

--- a/LogWatcher.Core/Processing/FileProcessor.cs
+++ b/LogWatcher.Core/Processing/FileProcessor.cs
@@ -143,6 +143,7 @@ namespace LogWatcher.Core.Processing
                 stats.Histogram.Add(v);
         }
 
+#pragma warning disable CS8524
         private static StatLevel ToStatLevel(ParsingLogLevel level) => level switch
         {
             ParsingLogLevel.Info  => StatLevel.Info,
@@ -150,8 +151,8 @@ namespace LogWatcher.Core.Processing
             ParsingLogLevel.Error => StatLevel.Error,
             ParsingLogLevel.Debug => StatLevel.Debug,
             ParsingLogLevel.Other => StatLevel.Other,
-            _ => throw new ArgumentOutOfRangeException(nameof(level), level, null),
         };
+#pragma warning restore CS8524
 
         [LoggerMessage(Level = Microsoft.Extensions.Logging.LogLevel.Debug, Message = "Processed path={Path} status={Status} bytesRead={BytesRead} lines={Lines} malformed={Malformed}")]
         private static partial void LogProcessed(ILogger logger, string path, TailReadStatus status, int bytesRead, long lines, long malformed);

--- a/LogWatcher.Core/Processing/ProcessingCoordinator.cs
+++ b/LogWatcher.Core/Processing/ProcessingCoordinator.cs
@@ -248,13 +248,14 @@ namespace LogWatcher.Core.Processing
         [LoggerMessage(Level = LogLevel.Debug, Message = "Skipped create/modify, delete pending path={Path}")]
         private static partial void LogSkippedDeletePending(ILogger logger, string path);
 
+#pragma warning disable CS8524
         private static StatEventKind ToStatEventKind(FsEventKind kind) => kind switch
         {
             FsEventKind.Created  => StatEventKind.Created,
             FsEventKind.Modified => StatEventKind.Modified,
             FsEventKind.Deleted  => StatEventKind.Deleted,
             FsEventKind.Renamed  => StatEventKind.Renamed,
-            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
         };
+#pragma warning restore CS8524
     }
 }

--- a/LogWatcher.Core/Processing/ProcessingCoordinator.cs
+++ b/LogWatcher.Core/Processing/ProcessingCoordinator.cs
@@ -105,7 +105,7 @@ namespace LogWatcher.Core.Processing
                 }
 
                 // Increment filesystem event counter in active stats
-                stats.Active.IncrementFsEvent(ev.Kind);
+                stats.Active.IncrementFsEvent(ToStatEventKind(ev.Kind));
 
                 // Route event
                 switch (ev.Kind)
@@ -247,5 +247,14 @@ namespace LogWatcher.Core.Processing
 
         [LoggerMessage(Level = LogLevel.Debug, Message = "Skipped create/modify, delete pending path={Path}")]
         private static partial void LogSkippedDeletePending(ILogger logger, string path);
+
+        private static StatEventKind ToStatEventKind(FsEventKind kind) => kind switch
+        {
+            FsEventKind.Created  => StatEventKind.Created,
+            FsEventKind.Modified => StatEventKind.Modified,
+            FsEventKind.Deleted  => StatEventKind.Deleted,
+            FsEventKind.Renamed  => StatEventKind.Renamed,
+            _ => throw new ArgumentOutOfRangeException(nameof(kind), kind, null),
+        };
     }
 }

--- a/LogWatcher.Core/Statistics/StatEventKind.cs
+++ b/LogWatcher.Core/Statistics/StatEventKind.cs
@@ -1,3 +1,18 @@
 namespace LogWatcher.Core.Statistics;
 
-public enum StatEventKind { Created, Modified, Deleted, Renamed }
+/// <summary>
+/// Statistics-internal filesystem-event bucket. Integer values are pinned to match
+/// <see cref="LogWatcher.Core.Ingestion.FsEventKind"/> so that per-kind counters
+/// in <see cref="WorkerStatsBuffer"/> remain index-compatible.
+/// </summary>
+public enum StatEventKind
+{
+    /// <summary>File created.</summary>
+    Created  = 0,
+    /// <summary>File modified.</summary>
+    Modified = 1,
+    /// <summary>File deleted.</summary>
+    Deleted  = 2,
+    /// <summary>File renamed.</summary>
+    Renamed  = 3
+}

--- a/LogWatcher.Core/Statistics/StatEventKind.cs
+++ b/LogWatcher.Core/Statistics/StatEventKind.cs
@@ -1,0 +1,3 @@
+namespace LogWatcher.Core.Statistics;
+
+public enum StatEventKind { Created, Modified, Deleted, Renamed }

--- a/LogWatcher.Core/Statistics/StatLevel.cs
+++ b/LogWatcher.Core/Statistics/StatLevel.cs
@@ -1,0 +1,3 @@
+namespace LogWatcher.Core.Statistics;
+
+public enum StatLevel { Info, Warn, Error, Debug, Other }

--- a/LogWatcher.Core/Statistics/StatLevel.cs
+++ b/LogWatcher.Core/Statistics/StatLevel.cs
@@ -1,3 +1,20 @@
 namespace LogWatcher.Core.Statistics;
 
-public enum StatLevel { Info, Warn, Error, Debug, Other }
+/// <summary>
+/// Statistics-internal log-level bucket. Integer values are pinned to match
+/// <see cref="LogWatcher.Core.Processing.Parsing.LogLevel"/> so that
+/// <see cref="WorkerStatsBuffer.LevelCounts"/> indices remain compatible.
+/// </summary>
+public enum StatLevel
+{
+    /// <summary>Informational messages.</summary>
+    Info  = 0,
+    /// <summary>Warning messages.</summary>
+    Warn  = 1,
+    /// <summary>Error messages.</summary>
+    Error = 2,
+    /// <summary>Debug-level messages.</summary>
+    Debug = 3,
+    /// <summary>Unrecognized or other levels.</summary>
+    Other = 4
+}

--- a/LogWatcher.Core/Statistics/WorkerStatsBuffer.cs
+++ b/LogWatcher.Core/Statistics/WorkerStatsBuffer.cs
@@ -101,7 +101,7 @@ namespace LogWatcher.Core.Statistics
                 case StatEventKind.Modified: FsModified++; break;
                 case StatEventKind.Deleted: FsDeleted++; break;
                 case StatEventKind.Renamed: FsRenamed++; break;
-                default: throw new ArgumentOutOfRangeException(nameof(kind));
+                default: break;
             }
         }
 

--- a/LogWatcher.Core/Statistics/WorkerStatsBuffer.cs
+++ b/LogWatcher.Core/Statistics/WorkerStatsBuffer.cs
@@ -1,6 +1,3 @@
-using LogWatcher.Core.Ingestion;
-using LogWatcher.Core.Processing.Parsing;
-
 namespace LogWatcher.Core.Statistics
 {
     /// <summary>
@@ -43,8 +40,8 @@ namespace LogWatcher.Core.Statistics
         /// <summary>Count of truncation resets.</summary>
         public long TruncationResetCount { get; set; }
 
-        // Level counts sized to LogLevel enum
-        /// <summary>Per-level counters indexed by <see cref="LogLevel"/>.</summary>
+        // Level counts sized to StatLevel enum
+        /// <summary>Per-level counters indexed by <see cref="StatLevel"/>.</summary>
         public long[] LevelCounts { get; set; }
 
         // Message counts (string keys)
@@ -64,7 +61,7 @@ namespace LogWatcher.Core.Statistics
         public WorkerStatsBuffer(int messageInitialCapacity = DefaultMessageCapacity)
         {
             // Initialize fields
-            LevelCounts = new long[Enum.GetNames<LogLevel>().Length];
+            LevelCounts = new long[Enum.GetNames<StatLevel>().Length];
             MessageCounts = new Dictionary<string, int>(messageInitialCapacity);
             Histogram = new LatencyHistogram();
         }
@@ -96,23 +93,23 @@ namespace LogWatcher.Core.Statistics
         /// Increment the appropriate filesystem event counter for <paramref name="kind"/>.
         /// </summary>
         /// <param name="kind">The filesystem event kind to increment.</param>
-        internal void IncrementFsEvent(FsEventKind kind)
+        internal void IncrementFsEvent(StatEventKind kind)
         {
             switch (kind)
             {
-                case FsEventKind.Created: FsCreated++; break;
-                case FsEventKind.Modified: FsModified++; break;
-                case FsEventKind.Deleted: FsDeleted++; break;
-                case FsEventKind.Renamed: FsRenamed++; break;
+                case StatEventKind.Created: FsCreated++; break;
+                case StatEventKind.Modified: FsModified++; break;
+                case StatEventKind.Deleted: FsDeleted++; break;
+                case StatEventKind.Renamed: FsRenamed++; break;
                 default: throw new ArgumentOutOfRangeException(nameof(kind));
             }
         }
 
         /// <summary>
-        /// Increment the counter for the specified <see cref="LogLevel"/>.
+        /// Increment the counter for the specified <see cref="StatLevel"/>.
         /// </summary>
         /// <param name="level">Level to increment.</param>
-        internal void IncrementLevel(LogLevel level)
+        internal void IncrementLevel(StatLevel level)
         {
             var idx = (int)level;
             if (idx < 0 || idx >= LevelCounts.Length) return;

--- a/LogWatcher.Tests/Integration/ReporterTests.cs
+++ b/LogWatcher.Tests/Integration/ReporterTests.cs
@@ -2,8 +2,8 @@ using LogWatcher.App;
 using LogWatcher.Core.Backpressure;
 using LogWatcher.Core.Coordination;
 using LogWatcher.Core.Ingestion;
-using LogWatcher.Core.Processing.Parsing;
 using LogWatcher.Core.Reporting;
+using LogWatcher.Core.Statistics;
 using LogWatcher.Tests.Helpers;
 
 namespace LogWatcher.Tests.Integration;
@@ -23,13 +23,13 @@ public class ReporterTests
         for (var i = 0; i < workers.Length; i++) workers[i] = new WorkerStats();
 
         // populate Active buffers
-        workers[0].Active.IncrementFsEvent(FsEventKind.Created);
-        workers[0].Active.IncrementLevel(LogLevel.Info);
+        workers[0].Active.IncrementFsEvent(StatEventKind.Created);
+        workers[0].Active.IncrementLevel(StatLevel.Info);
         workers[0].Active.IncrementMessage("k1");
         workers[0].Active.RecordLatency(10);
 
-        workers[1].Active.IncrementFsEvent(FsEventKind.Modified);
-        workers[1].Active.IncrementLevel(LogLevel.Warn);
+        workers[1].Active.IncrementFsEvent(StatEventKind.Modified);
+        workers[1].Active.IncrementLevel(StatLevel.Warn);
         workers[1].Active.IncrementMessage("k2");
         workers[1].Active.RecordLatency(100);
 
@@ -49,8 +49,8 @@ public class ReporterTests
         Assert.Equal(1, snap.FsCreated);
         Assert.Equal(1, snap.FsModified);
         // Level counts merged (ensure non-zero)
-        Assert.True(snap.LevelCounts[(int)LogLevel.Info] >= 1);
-        Assert.True(snap.LevelCounts[(int)LogLevel.Warn] >= 1);
+        Assert.True(snap.LevelCounts[(int)StatLevel.Info] >= 1);
+        Assert.True(snap.LevelCounts[(int)StatLevel.Warn] >= 1);
         // Assert message counts merged
         Assert.True(snap.MessageCounts.ContainsKey("k1"));
         Assert.True(snap.MessageCounts.ContainsKey("k2"));

--- a/LogWatcher.Tests/Unit/Core/Processing/FileProcessorTests.cs
+++ b/LogWatcher.Tests/Unit/Core/Processing/FileProcessorTests.cs
@@ -158,4 +158,30 @@ public class FileProcessorTests : IDisposable
             Assert.Equal(1, stats.LinesProcessed);
         }
     }
+
+    [Theory]
+    [InlineData("INFO",  StatLevel.Info)]
+    [InlineData("WARN",  StatLevel.Warn)]
+    [InlineData("ERROR", StatLevel.Error)]
+    [InlineData("DEBUG", StatLevel.Debug)]
+    [InlineData("OTHER", StatLevel.Other)]
+    public void ProcessOnce_EachLogLevelToken_IncrementsCorrectStatLevelBucket(string token, StatLevel expected)
+    {
+        var p = MakePath($"level_{token}.log");
+        File.WriteAllText(p, $"2023-01-02T03:04:05Z {token} key\n");
+
+        var fp = new FileProcessor();
+        var reg = new FileStateRegistry();
+        var state = reg.GetOrCreate(p);
+        lock (state.Gate)
+        {
+            var stats = new WorkerStatsBuffer();
+            fp.ProcessOnce(p, state, stats);
+            Assert.Equal(1, stats.LevelCounts[(int)expected]);
+            // All other buckets must remain zero
+            for (var i = 0; i < stats.LevelCounts.Length; i++)
+                if (i != (int)expected)
+                    Assert.Equal(0, stats.LevelCounts[i]);
+        }
+    }
 }

--- a/LogWatcher.Tests/Unit/Core/Statistics/WorkerStatsBufferTests.cs
+++ b/LogWatcher.Tests/Unit/Core/Statistics/WorkerStatsBufferTests.cs
@@ -81,4 +81,49 @@ public class WorkerStatsBufferTests
         });
         Assert.Null(ex);
     }
+
+    [Fact]
+    [Invariant("STAT-001")]
+    public void IncrementFsEvent_WithOutOfRangeKind_DoesNotThrow()
+    {
+        var buf = new WorkerStatsBuffer();
+        var ex = Record.Exception(() =>
+        {
+            buf.IncrementFsEvent((StatEventKind)9999);
+            buf.IncrementFsEvent((StatEventKind)(-1));
+        });
+        Assert.Null(ex);
+    }
+
+    [Fact]
+    public void IncrementLevel_EachStatLevelVariant_IncrementsCorrectBucket()
+    {
+        var buf = new WorkerStatsBuffer();
+        buf.IncrementLevel(StatLevel.Info);
+        buf.IncrementLevel(StatLevel.Warn);
+        buf.IncrementLevel(StatLevel.Error);
+        buf.IncrementLevel(StatLevel.Debug);
+        buf.IncrementLevel(StatLevel.Other);
+
+        Assert.Equal(1, buf.LevelCounts[(int)StatLevel.Info]);
+        Assert.Equal(1, buf.LevelCounts[(int)StatLevel.Warn]);
+        Assert.Equal(1, buf.LevelCounts[(int)StatLevel.Error]);
+        Assert.Equal(1, buf.LevelCounts[(int)StatLevel.Debug]);
+        Assert.Equal(1, buf.LevelCounts[(int)StatLevel.Other]);
+    }
+
+    [Fact]
+    public void IncrementFsEvent_EachStatEventKindVariant_IncrementsCorrectCounter()
+    {
+        var buf = new WorkerStatsBuffer();
+        buf.IncrementFsEvent(StatEventKind.Created);
+        buf.IncrementFsEvent(StatEventKind.Modified);
+        buf.IncrementFsEvent(StatEventKind.Deleted);
+        buf.IncrementFsEvent(StatEventKind.Renamed);
+
+        Assert.Equal(1, buf.FsCreated);
+        Assert.Equal(1, buf.FsModified);
+        Assert.Equal(1, buf.FsDeleted);
+        Assert.Equal(1, buf.FsRenamed);
+    }
 }

--- a/LogWatcher.Tests/Unit/Core/Statistics/WorkerStatsBufferTests.cs
+++ b/LogWatcher.Tests/Unit/Core/Statistics/WorkerStatsBufferTests.cs
@@ -1,4 +1,3 @@
-using LogWatcher.Core.Processing.Parsing;
 using LogWatcher.Core.Statistics;
 
 namespace LogWatcher.Tests.Unit.Core.Statistics;
@@ -59,26 +58,26 @@ public class WorkerStatsBufferTests
 
     [Fact]
     [Invariant("STAT-001")]
-    public void LevelCounts_IndexedByLogLevelEnumValue_OutOfRangeIndexIsIgnored()
+    public void LevelCounts_IndexedByStatLevelEnumValue_OutOfRangeIndexIsIgnored()
     {
         var buf = new WorkerStatsBuffer();
 
-        buf.IncrementLevel(LogLevel.Info);
-        buf.IncrementLevel(LogLevel.Warn);
-        buf.IncrementLevel(LogLevel.Error);
-        buf.IncrementLevel(LogLevel.Debug);
+        buf.IncrementLevel(StatLevel.Info);
+        buf.IncrementLevel(StatLevel.Warn);
+        buf.IncrementLevel(StatLevel.Error);
+        buf.IncrementLevel(StatLevel.Debug);
 
-        // Verify counts are indexed by the integer value of each LogLevel
-        Assert.Equal(1, buf.LevelCounts[(int)LogLevel.Info]);
-        Assert.Equal(1, buf.LevelCounts[(int)LogLevel.Warn]);
-        Assert.Equal(1, buf.LevelCounts[(int)LogLevel.Error]);
-        Assert.Equal(1, buf.LevelCounts[(int)LogLevel.Debug]);
+        // Verify counts are indexed by the integer value of each StatLevel
+        Assert.Equal(1, buf.LevelCounts[(int)StatLevel.Info]);
+        Assert.Equal(1, buf.LevelCounts[(int)StatLevel.Warn]);
+        Assert.Equal(1, buf.LevelCounts[(int)StatLevel.Error]);
+        Assert.Equal(1, buf.LevelCounts[(int)StatLevel.Debug]);
 
         // An unrecognized (out-of-range) index must be silently ignored — no exception
         var ex = Record.Exception(() =>
         {
-            buf.IncrementLevel((LogLevel)9999);
-            buf.IncrementLevel((LogLevel)(-1));
+            buf.IncrementLevel((StatLevel)9999);
+            buf.IncrementLevel((StatLevel)(-1));
         });
         Assert.Null(ex);
     }

--- a/README.md
+++ b/README.md
@@ -115,7 +115,6 @@ graph TB
 
         subgraph Parsing["Parsing"]
             LP["LogParser<br/>Parse Records"]
-            LL["LogLevel"]
             PLL["ParsedLogLine"]
         end
     end
@@ -124,6 +123,8 @@ graph TB
         WSB["WorkerStatsBuffer<br/>Per-Interval Metrics"]
         LH["LatencyHistogram<br/>Bounded Distribution"]
         TK["TopK<br/>Frequency Computation"]
+        SL["StatLevel"]
+        SEK["StatEventKind"]
     end
 
     subgraph Coordination_["Coordination"]
@@ -146,11 +147,11 @@ graph TB
     FT -->|Status| TRS
     FT -->|Raw Bytes| USS
     USS -->|Lines| LP
-    LP -->|Level| LL
     LP -->|ParsedLogLine| PLL
-    PLL -->|Counters| WSB
-    PLL -->|Message| TK
-    PLL -->|Latency| LH
+    PLL -->|LogLevel → StatLevel| FP
+    FP -->|Counters| WSB
+    FP -->|Message| TK
+    FP -->|Latency| LH
     WSB -->|Contains| Statistics
     TK -->|Contains| Statistics
     LH -->|Contains| Statistics

--- a/docs/domain_boundaries.md
+++ b/docs/domain_boundaries.md
@@ -263,7 +263,7 @@ Log format changes (timestamp format, level values, field names), new fields to 
 - Behavioral, inbound: `TryParse(ReadOnlySpan<byte> line, out ParsedLogLine parsed) → bool` — parses a UTF-8 line into a structured record; returns false only when timestamp parsing fails or required tokens are absent (PRS-001); the `MessageKey` span inside the returned `ParsedLogLine` is only valid for the duration of the enclosing `onLine` callback (PRS-004)
 - Behavioral, outbound: none
 - Data, outbound: `ParsedLogLine` to File Processing — structured record consumed inline during the `onLine` callback; `MessageKey` span is only valid for the enclosing callback duration (PRS-004)
-- Data, outbound: `LogLevel` to File Processing, CLI & Host — log-level enum read when translating to `StatLevel` before incrementing per-level counters, and when formatting level counts in reports
+- Data, outbound: `LogLevel` to File Processing — log-level enum read from `ParsedLogLine.Level` and translated to `StatLevel` before crossing the Statistics Collection boundary via `IncrementLevel`
 - Data, inbound: none
 
 **Dependency Direction:** none
@@ -365,7 +365,7 @@ timing changes.
 - Data, inbound: `WorkerStatsBuffer` from Statistics Collection — active buffer accessed via `WorkerStats.Active` and passed to `ProcessOnce`
 - Data, inbound: `StatEventKind` from Statistics Collection — target type for the `FsEventKind → StatEventKind` translation performed before calling `IncrementFsEvent`
 
-**Dependency Direction:** depends on Event Distribution, File State Management, File Processing, Worker Coordination, Statistics Collection
+**Dependency Direction:** depends on Ingestion, Event Distribution, File State Management, File Processing, Worker Coordination, Statistics Collection
 
 ---
 
@@ -549,9 +549,8 @@ shutdown sequence changes.
 - Data, inbound: `GlobalSnapshot` from Reporting — received via `ISnapshotConsumer.OnSnapshot` for console formatting
 - Data, inbound: `BoundedEventBus<FsEvent>` from Event Distribution — constructed here and passed to Ingestion, Processing Coordination, and Reporting
 - Data, inbound: `WorkerStats` from Worker Coordination — constructed here as an array and passed to Processing Coordination and Reporting
-- Data, inbound: `LogLevel` from Log Parsing — referenced when formatting per-level counts from `GlobalSnapshot.LevelCounts`
 
-**Dependency Direction:** depends on Ingestion, Event Distribution, File State Management, File Tailing, Line Scanning, Log Parsing, File Processing, Processing Coordination, Statistics Collection, Worker Coordination, Reporting
+**Dependency Direction:** depends on Ingestion, Event Distribution, File State Management, File Tailing, File Processing, Processing Coordination, Worker Coordination, Reporting
 
 ---
 

--- a/docs/system_diagram.md
+++ b/docs/system_diagram.md
@@ -4,85 +4,85 @@
 
 ```mermaid
 graph TB
-    subgraph Input["Input Layer"]
+    subgraph Ingestion["Ingestion"]
         FS["File System"]
-        FSW["FileSystemWatcher"]
+        FSW["FilesystemWatcherAdapter"]
+        FEV["FsEvent<br/>Created|Modified|Deleted|Renamed"]
     end
 
-    subgraph EventBus["Event Bus Layer"]
-        BEB["BoundedEventBus&lt;FsEvent&gt;"]
-        EV["FsEvent<br/>Created|Modified|Deleted|Renamed"]
+    subgraph Backpressure["Backpressure"]
+        BEB["BoundedEventBus&lt;T&gt;"]
     end
 
-    subgraph Coordination["Coordination Layer"]
-        PC["ProcessingCoordinator<br/>N Worker Threads"]
+    subgraph FileManagement["FileManagement"]
         FSR["FileStateRegistry<br/>Per-File State Machine"]
+        FS_State["FileState<br/>Offset + Flags + Gate"]
+        PLB["PartialLineBuffer<br/>Carryover Storage"]
     end
 
-    subgraph Processing["Processing Layer"]
-        FP["FileProcessor<br/>Read & Parse"]
-        FT["FileTailer<br/>Track File Position"]
-        LP["LogParser<br/>Parse Log Lines"]
-        USS["Utf8LineScanner<br/>Span-based Scanning"]
+    subgraph Processing["Processing"]
+        PC["ProcessingCoordinator<br/>N Worker Threads"]
+        FP["FileProcessor<br/>Orchestrator"]
+
+        subgraph Tailing["Tailing"]
+            FT["FileTailer<br/>Chunked Reads"]
+            TRS["TailReadStatus"]
+        end
+
+        subgraph Scanning["Scanning"]
+            USS["Utf8LineScanner<br/>Line Splitting"]
+        end
+
+        subgraph Parsing["Parsing"]
+            LP["LogParser<br/>Parse Records"]
+            PLL["ParsedLogLine"]
+        end
     end
 
-    subgraph Metrics["Metrics & Stats Layer"]
-        WS["WorkerStats<br/>Per-Worker Stats"]
-        WSB["WorkerStatsBuffer<br/>Swap Buffer"]
-        LH["LatencyHistogram<br/>Track Latencies"]
-        TK["TopK<br/>Most Frequent Messages"]
-        GS["GlobalSnapshot<br/>Aggregate View"]
+    subgraph Statistics["Statistics"]
+        WSB["WorkerStatsBuffer<br/>Per-Interval Metrics"]
+        LH["LatencyHistogram<br/>Bounded Distribution"]
+        TK["TopK<br/>Frequency Computation"]
+        SL["StatLevel"]
+        SEK["StatEventKind"]
     end
 
-    subgraph Reporting["Reporting Layer"]
-        REP["Reporter<br/>Format & Output"]
-        STDOUT["Console Output"]
+    subgraph Coordination_["Coordination"]
+        WS["WorkerStats<br/>Double-Buffer Swap Protocol"]
     end
 
-    subgraph CLI["CLI Layer"]
-        PROG["Program<br/>Entry Point"]
-        CLIP["CliParser<br/>Parse Arguments"]
-        CLIC["CliConfig<br/>Configuration"]
-        HW["HostWiring<br/>Dependency Injection"]
+    subgraph Reporting["Reporting"]
+        GS["GlobalSnapshot<br/>Merged Interval View"]
+        REP["Reporter<br/>Aggregation & Output"]
     end
 
-    %% Input connections
     FS -->|File Changes| FSW
-    FSW -->|Adapt Events| FSA["FilesystemWatcherAdapter"]
-    FSA -->|Publish FsEvent| BEB
-
-    %% Event Bus
+    FSW -->|FsEvent| BEB
     BEB -->|Dequeue| PC
-
-    %% Coordination & Registry
-    PC -->|Lookup Per-File State| FSR
-    PC -->|Process File| FP
-    PC -->|Update Worker Stats| WS
-
-    %% Processing Pipeline
-    FP -->|Read Tail| FT
+    PC -->|Lookup/Create| FSR
+    FSR -->|State| FS_State
+    FS_State -->|Carryover| PLB
+    PC -->|Orchestrate| FP
+    FP -->|Read Chunks| FT
+    FT -->|Status| TRS
     FT -->|Raw Bytes| USS
     USS -->|Lines| LP
-    LP -->|ParsedLogLine| FP
-
-    %% Metrics Collection (via FileProcessor translation)
-    FP -->|Counters| WS
+    LP -->|ParsedLogLine| PLL
+    PLL -->|LogLevel → StatLevel| FP
+    FP -->|Counters| WSB
     FP -->|Message| TK
     FP -->|Latency| LH
-    WS -->|Buffer| WSB
-    WSB -->|Swap| GS
-
-    %% Reporting
-    GS -->|Aggregate Stats| REP
-    REP -->|Format Output| STDOUT
-
-    %% CLI Wiring
-    PROG -->|Parse| CLIP
-    CLIP -->|Create Config| CLIC
-    CLIC -->|Wire Components| HW
-    HW -->|Start| PC
-    HW -->|Start| FSA
-    HW -->|Periodic| REP
+    WSB -->|Contains| Statistics
+    TK -->|Contains| Statistics
+    LH -->|Contains| Statistics
+    PC -->|Coordinates| WS
+    WS -->|Owns| WSB
+    WS -->|Swap Request| REP
+    WSB -->|Merge| GS
+    TK -->|Merge| GS
+    LH -->|Merge| GS
+    GS -->|Snapshot| REP
+    REP -->|Output| STDOUT["Console Output"]
 
 ```
 

--- a/docs/system_diagram.md
+++ b/docs/system_diagram.md
@@ -136,9 +136,10 @@ graph LR
     G -->|Get Position| H
     H -->|New Bytes| I
     I -->|LogRecord| J
-    J -->|Stats| K
-    J -->|Message| L
-    J -->|Latency| M
+    J -->|LogLevel → StatLevel| G
+    G -->|Counters| K
+    G -->|Message| L
+    G -->|Latency| M
     K -->|Swap Buffer| N
     L -->|Swap Buffer| N
     M -->|Swap Buffer| N
@@ -172,6 +173,8 @@ graph TB
         LH["LatencyHistogram<br/>• Median<br/>• P95, P99"]
         TK["TopK<br/>Most frequent<br/>message keys"]
         GS["GlobalSnapshot<br/>Aggregated metrics"]
+        SL["StatLevel<br/>Info|Warn|Error|Debug|Other"]
+        SEK["StatEventKind<br/>Created|Modified|Deleted|Renamed"]
     end
 
     FEV -.-> FEVK

--- a/docs/system_diagram.md
+++ b/docs/system_diagram.md
@@ -63,12 +63,12 @@ graph TB
     FP -->|Read Tail| FT
     FT -->|Raw Bytes| USS
     USS -->|Lines| LP
-    LP -->|LogRecord| Metrics
+    LP -->|ParsedLogLine| FP
 
-    %% Metrics Collection
-    LP -->|Timestamp, Level| WS
-    LP -->|Message Key| TK
-    LP -->|Latency| LH
+    %% Metrics Collection (via FileProcessor translation)
+    FP -->|Counters| WS
+    FP -->|Message| TK
+    FP -->|Latency| LH
     WS -->|Buffer| WSB
     WSB -->|Swap| GS
 
@@ -135,7 +135,7 @@ graph LR
     D -->|Read File| G
     G -->|Get Position| H
     H -->|New Bytes| I
-    I -->|LogRecord| J
+    I -->|ParsedLogLine| J
     J -->|LogLevel → StatLevel| G
     G -->|Counters| K
     G -->|Message| L
@@ -158,17 +158,17 @@ graph TB
     end
 
     subgraph Records["Log Records"]
-        LOGR["LogRecord<br/>• Timestamp: DateTimeOffset<br/>• Level: LogLevel<br/>• MessageKey: ReadOnlySpan&lt;byte&gt;<br/>• LatencyMs: int?"]
-        LOGLVL["LogLevel<br/>Trace|Debug|Info<br/>Warn|Error|Fatal|Other"]
+        LOGR["ParsedLogLine<br/>• Timestamp: DateTimeOffset<br/>• Level: LogLevel<br/>• MessageKey: ReadOnlySpan&lt;byte&gt;<br/>• LatencyMs: int?"]
+        LOGLVL["LogLevel<br/>Info|Warn|Error|Debug|Other"]
     end
 
     subgraph FileState["File State Machine"]
-        FSTATE["FileState<br/>• Path: string<br/>• Position: long<br/>• LastObservedSize: long<br/>• IsDeleted: bool<br/>• Epoch: uint"]
+        FSTATE["FileState<br/>• Offset: long<br/>• Carry: PartialLineBuffer<br/>• Generation: int<br/>• IsDirty: bool<br/>• IsDeletePending: bool"]
         FSREG["FileStateRegistry<br/>Registry of all active<br/>file states"]
     end
 
     subgraph Stats["Statistics"]
-        WS["WorkerStats<br/>• LineCount<br/>• ErrorCount<br/>• TopK"]
+        WS["WorkerStats<br/>• Active: WorkerStatsBuffer<br/>• Inactive: WorkerStatsBuffer<br/>• Swap protocol"]
         WSB["WorkerStatsBuffer<br/>Current + Swap"]
         LH["LatencyHistogram<br/>• Median<br/>• P95, P99"]
         TK["TopK<br/>Most frequent<br/>message keys"]
@@ -262,7 +262,7 @@ sequenceDiagram
 graph LR
     A["Raw File<br/>Bytes"] -->|Read Chunk<br/>via FileTailer| B["Partial Line<br/>Buffer"]
     B -->|Utf8LineScanner<br/>ReadOnlySpan&lt;byte&gt;| C["Complete<br/>Log Line"]
-    C -->|Parse<br/>LogParser| D["LogRecord<br/>Timestamp<br/>Level<br/>Message Key<br/>Latency"]
+    C -->|Parse<br/>LogParser| D["ParsedLogLine<br/>Timestamp<br/>Level<br/>Message Key<br/>Latency"]
     D -->|Extract| E["Message Key<br/>String"]
     D -->|Extract| F["Latency<br/>int?"]
     E -->|TopK.Observe| G["TopK<br/>Frequency Map"]


### PR DESCRIPTION
## Problem

`WorkerStatsBuffer` declared `IncrementFsEvent(FsEventKind kind)` and `IncrementLevel(LogLevel level)`, making the Statistics Collection schema co-governed by two foreign Postulates. A new log level or filesystem event kind forced a schema change in `WorkerStatsBuffer` even though Statistics Collection's Reason to Change — metrics accumulation schema — was untouched. This is a domain boundary violation: Statistics Collection compiled against both `LogWatcher.Core.Ingestion` and `LogWatcher.Core.Processing.Parsing`.

## Solution

Introduce `StatEventKind` and `StatLevel` as Statistics-owned enums and push the type translations to the two call sites that have both types in scope.

**`LogWatcher.Core/Statistics/`**
- `StatLevel.cs`: `{ Info, Warn, Error, Debug, Other }` — integer values match `LogLevel` (0–4) so `WorkerStatsBuffer.LevelCounts` and `GlobalSnapshot.LevelCounts` stay index-compatible without touching Reporting
- `StatEventKind.cs`: `{ Created, Modified, Deleted, Renamed }` — integer values match `FsEventKind` for the same reason
- `WorkerStatsBuffer`: removes `using` directives for both foreign namespaces; `IncrementFsEvent` and `IncrementLevel` now take the Statistics-owned types; `IncrementFsEvent` silently ignores unrecognized kinds, matching STAT-001 behavior for `IncrementLevel`

**`LogWatcher.Core/Processing/FileProcessor.cs`**
- Adds `ToStatLevel(ParsingLogLevel)` private static helper with a `using` alias to resolve the `LogLevel` ambiguity with `Microsoft.Extensions.Logging.LogLevel`
- `#pragma warning disable CS8524` suppresses the unnamed-enum exhaustiveness warning so the switch has no `_` arm; adding a new named `LogLevel` variant without updating the switch produces CS8509 → compile error under `TreatWarningsAsErrors`

**`LogWatcher.Core/Processing/ProcessingCoordinator.cs`**
- `FsEventKind → StatEventKind` translation lives here, not in `FileProcessor`, because `ev.Kind` is only in scope inside `WorkerLoop`; `ProcessOnce` never receives the event kind
- Same `#pragma warning disable CS8524` / no `_` arm pattern for compile-time exhaustiveness

**Tests**
- `WorkerStatsBufferTests`: adds `IncrementFsEvent_WithOutOfRangeKind_DoesNotThrow` (STAT-001), `IncrementLevel_EachStatLevelVariant_IncrementsCorrectBucket`, `IncrementFsEvent_EachStatEventKindVariant_IncrementsCorrectCounter`
- `FileProcessorTests`: adds `ProcessOnce_EachLogLevelToken_IncrementsCorrectStatLevelBucket` `[Theory]` — drives each log level token (INFO/WARN/ERROR/DEBUG/OTHER) through the real `ProcessOnce` path and asserts the correct `StatLevel` bucket incremented with all others at zero
- `ReporterTests`, `WorkerStatsBufferTests`: updated call sites to use `StatEventKind`/`StatLevel`

**`docs/domain_boundaries.md`**
- Statistics Collection: `StatLevel` and `StatEventKind` added to Data Ownership; `IncrementFsEvent`/`IncrementLevel` contract descriptions updated; Dependency Direction corrected to `none`
- File Processing and Processing Coordination: `StatLevel`/`StatEventKind` added as data inbound
- Domain 8 Dependency Direction: Ingestion added (was missing — `ProcessingCoordinator` imports `FsEvent`/`FsEventKind` from `LogWatcher.Core.Ingestion`)
- Domain 12 Dependency Direction and data inbound: removed stale Log Parsing, Line Scanning, and Statistics Collection entries; the `LogLevel` in CLI & Host is `Microsoft.Extensions.Logging.LogLevel` (logging config), not the Log Parsing enum; `ConsoleSnapshotConsumer` does not reference `LevelCounts`

## Test plan

- [x] `dotnet build` — 0 warnings, 0 errors (verified; `TreatWarningsAsErrors` is active)
- [x] `dotnet test` — 249/249 passed (8 new tests)
- [x] `grep -r "FsEventKind|LogLevel" LogWatcher.Core/Statistics/` — 0 matches

Closes #54